### PR TITLE
Better error handling, code cleanup

### DIFF
--- a/include/phiSerialPort.h
+++ b/include/phiSerialPort.h
@@ -23,13 +23,17 @@ extern "C"
     ////////////////////////////////////////////////////////////
     // define error types
 
-#define ERROR_OPEN_FILE_FORMAT 0
-#define COM_GET_DCB_ERROR 1
-#define COM_GET_DCB_ASSIGNING_ERROR 2
-#define COM_TIME_OUT_ERROR 3
-#define ERROR_SET_COMM_MASK 4
-#define ERROR_WAIT_COMM_MASK 5
-#define ERROR_WRITE_DATA 6
+typedef enum{
+	PHI_OK = 0,
+	ERROR_OPEN_FILE_FORMAT,
+	COM_GET_DCB_ERROR,
+	COM_GET_DCB_ASSIGNING_ERROR,
+	COM_TIME_OUT_ERROR,
+	ERROR_SET_COMM_MASK,
+	ERROR_WAIT_COMM_MASK,
+	ERROR_WRITE_DATA,
+	COUNT
+}PHI_ERROR;
 
     // define error types
     ////////////////////////////////////////////////////////////
@@ -123,6 +127,7 @@ extern "C"
                           * storing the name of file
                           */
 
+		PHI_ERROR lastError;
         // writing text file
         //////////////////////////////////////////////////////////
 
@@ -175,7 +180,14 @@ extern "C"
     ////////////////////////////////////////////////////////////
     // error handler code
 
-    void phiErrorHandler(phiSerialPortParametersPtr ptrPSP, int errorType); /*
+    /*
+    * returns description of given error, if one is provided in table. 
+    */
+    const char* phiGetErrorDescription(PHI_ERROR errorType);
+
+
+    void phiErrorHandler(phiSerialPortParametersPtr ptrPSP, PHI_ERROR error);
+    /*
     * return error type
     * output -> return nothing
     * input -> address of phiSerialPortParametersPtr

--- a/phiMain.c
+++ b/phiMain.c
@@ -9,11 +9,24 @@ int main()
 
     phiSP.fileName = "portReading.txt";
 
-    phiSpInitialization(&phiSP, "COM3", "r", CBR_115200, 8, ONESTOPBIT, NOPARITY);
+    if(TRUE == phiSpInitialization(&phiSP, "COM3", "r", CBR_115200, 8, ONESTOPBIT, NOPARITY)){
+		if(TRUE == phiStartSerialConnection(&phiSP)){
+			if(TRUE == phiReadData(&phiSP)){
+				// success!				
+			}
+			else{
+				fprintf(stdout, "Unable to read serial port, error desc : %s\n", phiGetErrorDescription(phiSP.lastError));				
+			}
+		}
+		else{
+			 fprintf(stdout, "Unable to start serial connection, error desc : %s\n", phiGetErrorDescription(phiSP.lastError)); 
+		}
+    	
+    }
+    else{
+    	fprintf(stdout, "Error occured, desc : %s\n", phiGetErrorDescription(phiSP.lastError));
+    }
 
-    phiStartSerialConnection(&phiSP);
-
-    phiReadData(&phiSP);
 
     return 0;
 }


### PR DESCRIPTION
Terminating with first error is not a good idea, what you want from an API is to provide error codes and descriptions to provide more descriptive feedback to user-programmer. Seems like your old API was not returning any value(even though you declared them as they were), but simply just terminating whole application. Keeping internal error code in your com struct and one big error description table in phiGetErrorDescription() fits your code cleanly. Don't forget to update phiGetErrorDescription() function in case you add new error codes, otherwise it would return some default string that doesn't mean anything. 


best regards, Batuhan, YTU MKT   